### PR TITLE
Update synchronize.js

### DIFF
--- a/src/synchronize.js
+++ b/src/synchronize.js
@@ -1,6 +1,6 @@
 /**
  * Synchronize.js
- * Version 1.2.6
+ * Version 1.2.7
  *
  * Copyright (c) 2013-2016, Denis Meyer, calltopower88@googlemail.com
  * All rights reserved.
@@ -1036,6 +1036,7 @@
             .on('sjs:stopBufferChecker', function() {
                 log('SJS: Received \'sjs:stopBufferChecker\' event');
                 window.clearInterval(bufferChecker);
+                checkBuffer = false;
                 bufferCheckerSet = false;
                 isBuffering = false;
             });


### PR DESCRIPTION
In general buffer checking does not work at all (tested with the latest versions of Chrome, Safari and Firefox and videos > 1h). 

But turning off buffer checking permanently does not work currently too, as checkBuffer = false has been removed from sjs:stopBufferChecker. Without setting this, buffer checking will be enabled again as soon as someone presses play.
