### PR TITLE
Fix for setBufferChecker, which keeps video in pause state. Checking…

### DIFF
--- a/src/synchronize.js
+++ b/src/synchronize.js
@@ -752,17 +752,11 @@
             for (i = 0; i < videoIds.length; ++i) {
                 var bufferedTimeRange = getBufferTimeRange(videoIds[i]);
                 if (bufferedTimeRange) {
-                    var duration = getDuration(videoIds[i]);
-                    var currTimePlusBuffer = getCurrentTime(videoIds[i]) + bufferInterval;
+                    var currentTime = getCurrentTime(videoIds[i]);
                     var buffered = false;
                     for (var j = 0;
-                        (j < bufferedTimeRange.length) && !buffered; ++j) {
-                        currTimePlusBuffer = (currTimePlusBuffer >= duration) ? duration : currTimePlusBuffer;
-                        if (isInInterval(currTimePlusBuffer,
-                                bufferedTimeRange.start(j),
-                                bufferedTimeRange.end(j) + bufferThreshold)) {
-                            buffered = true;
-                        }
+                         (j < bufferedTimeRange.length) && !buffered; ++j) {
+                        buffered = isInInterval(currentTime, bufferedTimeRange.start(j), bufferedTimeRange.end(j));
                     }
                     allBuffered = allBuffered && buffered;
                     isBuffering = !allBuffered;


### PR DESCRIPTION
… for _currentTime + bufferInterval_ may fail in some browsers, cause _bufferInterval_ conflicts with implementation details of browsers and hence not required for the check. You cannot control how much a browser will buffer. Chrome Version 51.0.2704.103 (64-bit) never reached the threshold _bufferInterval_ after moving to an uncached part of the video.

Reproduce: Move currentTime to an part of the video that is not yet buffered and the player will stall in pause mode.